### PR TITLE
Add Cook-off event tag for gallery filtering

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -13,3 +13,5 @@ tags:
     - scipy
     - pandas
     - pywavelets
+  events:
+    - Cook-off 2024


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR adds a new "Cook-off 2024" event tag so the cookbook will be findable in the Pythia gallery along with other contributions associated with the 2024 event.

No effect on the cookbook itself.