### PR TITLE
Update _gallery_info.yml to add events tag

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -13,3 +13,5 @@ tags:
     - scipy
     - pandas
     - pywavelets
+  events:
+    - Cook-off 2024


### PR DESCRIPTION
Added an events tag to mention this cookbooks was a result of Cookoff 2024
